### PR TITLE
TypeError when OneHotEncoder object is created

### DIFF
--- a/_questions/machine-learning-zoomcamp/module-4-homework/TypeError when OneHotEncoder class is created
+++ b/_questions/machine-learning-zoomcamp/module-4-homework/TypeError when OneHotEncoder class is created
@@ -1,0 +1,11 @@
+TypeError Traceback (most recent call last) 
+Cell In[60], line 4 
+2 scaler = StandardScaler() 
+3 X_train_num = scaler.fit_transform(X_train_num) 
+----> 4 ohe = OneHotEncoder(sparse=False)
+5 X_train_cat = ohe.fit_transform(df_train[categorical_columns].values) 
+6 X_train_cat
+
+You get above error when categorical values are oneHotEncoded using sparse as parameter. This is because in scikit-learn ≥1.2, the OneHotEncoder no longer uses the sparse parameter. Instead, it now uses sparse_output.
+So create OneHotEncoder class using spare_output as argument like below,
+ohe = OneHotEncoder(sparse_output=False)


### PR DESCRIPTION
TypeError occurs  when OneHotEncoder object is created with sparse as parameter for oneHotEncoding categorical variables as in scikit-learn ≥1.2, this parameter is deprecated