### PR TITLE
Clarify non-Python language policy and make it retrievable by language name

### DIFF
--- a/_questions/llm-zoomcamp/project/012_ea815eb858_can-i-use-something-other-than-python-for-homework-or-project.md
+++ b/_questions/llm-zoomcamp/project/012_ea815eb858_can-i-use-something-other-than-python-for-homework-or-project.md
@@ -1,16 +1,16 @@
 ---
 id: ea815eb858
-question: Can I use something other than Python for homework or the project?
+question: Can I use a programming language other than Python (for example JavaScript, TypeScript, Go, Rust, Java, Scala, C#, or R) for homework or the project?
 sort_order: 12
 ---
 
-In most cases, use Python. The course materials, examples, and reviewer expectations are Python-based, so Python is the easiest path.
+In most cases, use Python. The course materials, examples, and reviewer expectations are Python-based, so Python is the easiest path. This applies to every homework and to the final/capstone project.
 
-Using another language or stack is technically possible, but do it only if you have a strong reason. We do not want to restrict your choice of technology, but using a different stack makes reproducibility and review harder.
+Using another programming language or stack - for example JavaScript, TypeScript, Go, Rust, Java, Scala, C#, or R - is technically possible, but do it only if you have a strong reason. We do not want to restrict your choice of technology, but a non-Python stack makes reproducibility and review harder.
 
-If you use another language, for example Go, your documentation must be very thorough. Assume the reviewer has no knowledge of that language or ecosystem. Your README should explain how to install dependencies and run the homework or project on Windows, macOS, and Linux.
+If you use a language other than Python, your documentation must be very thorough. Assume the reviewer has no knowledge of that language or ecosystem. Your README should explain how to install dependencies and run the homework or project on Windows, macOS, and Linux.
 
-For Go, include steps at the level of:
+For example, a Go project should include steps at the level of:
 
 ```bash
 go mod tidy


### PR DESCRIPTION
## Why

The FAQ assistant kept missing this entry for questions phrased with a *specific* language, e.g. "Can we use TypeScript for the final project?". The assistant's retrieval is keyword-based, and the entry only contained the words "Python" and "Go" — so "TypeScript", "JavaScript", "Rust", etc. had nothing to match, and the entry didn't surface (a more permissive docs page answered instead).

## What

- The question now names the languages people actually ask about (JavaScript, TypeScript, Go, Rust, Java, Scala, C#, R) instead of only the generic "something other than Python". The `question` field is the highest-weighted retrieval field, so naming them here is what makes the entry match.
- The answer body is unchanged in substance (default to Python; another stack is allowed with a strong reason and thorough docs) — just lists the same example languages and states it applies to all homework and the capstone.
- `id` (`ea815eb858`) and `sort_order` are unchanged, so the deep link is stable.

Verified against the assistant's index: with this wording, "TypeScript / JavaScript / Rust / Go / C# / Java for the project/homework" all retrieve this entry at rank #1 (previously not in the top results).